### PR TITLE
Fix inflated session hours with active duration calculation

### DIFF
--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -12,6 +12,7 @@ from claude_history_explorer.history import (
     Project,
     ProjectStats,
     GlobalStats,
+    active_duration_minutes,
     # V3 imports
     SessionInfoV3,
     ProjectStatsV3,
@@ -217,6 +218,91 @@ class TestSession:
         
         assert session.message_count == 3
         assert session.user_message_count == 2
+
+
+class TestActiveDuration:
+    """Test active_duration_minutes function."""
+
+    def test_active_duration_basic(self):
+        """Test basic active duration calculation."""
+        messages = [
+            Message(role="user", content="Hello", timestamp=datetime(2025, 12, 15, 10, 0)),
+            Message(role="assistant", content="Hi", timestamp=datetime(2025, 12, 15, 10, 5)),
+            Message(role="user", content="How are you?", timestamp=datetime(2025, 12, 15, 10, 10)),
+        ]
+
+        duration = active_duration_minutes(messages)
+
+        # 5 min + 5 min = 10 min
+        assert duration == 10
+
+    def test_active_duration_caps_large_gaps(self):
+        """Test that large gaps are capped at max_gap_minutes."""
+        messages = [
+            Message(role="user", content="Hello", timestamp=datetime(2025, 12, 15, 10, 0)),
+            Message(role="assistant", content="Hi", timestamp=datetime(2025, 12, 15, 10, 5)),
+            # 4 hour gap (left session open)
+            Message(role="user", content="Back", timestamp=datetime(2025, 12, 15, 14, 5)),
+        ]
+
+        duration = active_duration_minutes(messages, max_gap_minutes=30)
+
+        # 5 min + 30 min (capped) = 35 min
+        assert duration == 35
+
+    def test_active_duration_overnight_gap(self):
+        """Test that overnight gaps are properly capped."""
+        messages = [
+            Message(role="user", content="Goodnight", timestamp=datetime(2025, 12, 15, 23, 0)),
+            Message(role="assistant", content="Night", timestamp=datetime(2025, 12, 15, 23, 5)),
+            # Next morning
+            Message(role="user", content="Morning", timestamp=datetime(2025, 12, 16, 9, 0)),
+        ]
+
+        duration = active_duration_minutes(messages, max_gap_minutes=30)
+
+        # 5 min + 30 min (capped) = 35 min (not 600+ min)
+        assert duration == 35
+
+    def test_active_duration_single_message(self):
+        """Test with single message returns 0."""
+        messages = [
+            Message(role="user", content="Hello", timestamp=datetime(2025, 12, 15, 10, 0)),
+        ]
+
+        duration = active_duration_minutes(messages)
+        assert duration == 0
+
+    def test_active_duration_empty_messages(self):
+        """Test with empty messages returns 0."""
+        duration = active_duration_minutes([])
+        assert duration == 0
+
+    def test_active_duration_no_timestamps(self):
+        """Test with messages without timestamps returns 0."""
+        messages = [
+            Message(role="user", content="Hello"),
+            Message(role="assistant", content="Hi"),
+        ]
+
+        duration = active_duration_minutes(messages)
+        assert duration == 0
+
+    def test_active_duration_custom_max_gap(self):
+        """Test with custom max_gap_minutes."""
+        messages = [
+            Message(role="user", content="Hello", timestamp=datetime(2025, 12, 15, 10, 0)),
+            # 2 hour gap
+            Message(role="assistant", content="Hi", timestamp=datetime(2025, 12, 15, 12, 0)),
+        ]
+
+        # With 60 min cap
+        duration_60 = active_duration_minutes(messages, max_gap_minutes=60)
+        assert duration_60 == 60
+
+        # With 15 min cap
+        duration_15 = active_duration_minutes(messages, max_gap_minutes=15)
+        assert duration_15 == 15
 
 
 class TestProjectStats:


### PR DESCRIPTION
## Summary

Session duration was calculated as `end_time - start_time`, which massively inflated hours when sessions were left open overnight or for days. One user reported **4956 hours** when actual active work was **~187 hours**.

## The fix

Added `active_duration_minutes()` that sums gaps between consecutive messages, capping each gap at 30 minutes (configurable).

**Example:**
- Messages at 10:00, 10:05, 10:10, then 14:00 (4 hour gap from lunch)
- Old duration: 240 minutes
- New duration: 5 + 5 + 30 = 40 minutes

## Changes

- `history.py`: Added `active_duration_minutes()` function
- `history.py`: Modified `SessionInfoV3.from_session_with_project()` to use active duration
- `test_history.py`: Added 7 unit tests for the new function

## Test plan

- [x] 7 new tests pass for `active_duration_minutes()`
- [x] Existing tests pass (196 passed, 3 pre-existing TS dependency failures)
- [x] Tested on real data: 4956h → 187h active

Fixes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)