### PR TITLE
fix: Windows compatibility — project discovery and terminal encoding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Claude History Explorer
+
+Python CLI tool to explore, search, and visualize Claude Code conversation history.
+
+**GitHub:** thenullwell/claude-history-explorer
+**MAVERICK relevance:** Transcript mining for INT-077 (Constitutional Articles), INT-078 (Conversation Import)
+
+---
+
+## What This Is
+
+Reads `~/.claude/projects/` JSONL files and provides:
+- Session search (regex across all conversations)
+- Story generation (work patterns, personality, collaboration style)
+- Concurrent Claude detection
+- Multiple export formats (JSON, Markdown, plain text)
+- Rich terminal UI (tables, panels, sparklines)
+
+Read-only by design — never modifies history files.
+
+---
+
+## Usage
+
+```bash
+# Install
+pip install -e .
+
+# Search sessions
+claude-history search "MAVERICK"
+
+# List sessions
+claude-history list
+```
+
+---
+
+## Git Workflow
+
+Commit message format: `<type>: <description>` (feat, fix, docs, chore, test, refactor)
+
+---
+
+## Related
+
+- **Mimir transcript miner:** `~/mimir/tools/transcript-miner.py` (complementary tool)
+- **Conversation archive:** `~/mimir/tools/conversation-archive.py` (web export importer)

--- a/claude_history_explorer/cli.py
+++ b/claude_history_explorer/cli.py
@@ -17,12 +17,19 @@ Commands:
 
 import json
 import re
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List, Optional
 
 import click
 from rich.console import Console
+
+# Windows terminals default to cp1252 which can't render Unicode content
+# (emojis, em dashes, etc.) from Claude Code transcripts. Force UTF-8.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
 from rich.table import Table
 from rich.panel import Panel
 from rich.syntax import Syntax

--- a/claude_history_explorer/projects.py
+++ b/claude_history_explorer/projects.py
@@ -50,7 +50,7 @@ def list_projects() -> List[Project]:
 
     projects = []
     for item in projects_dir.iterdir():
-        if item.is_dir() and item.name.startswith("-"):
+        if item.is_dir() and not item.name.startswith("."):
             projects.append(Project.from_dir(item))
 
     # Sort by last modified


### PR DESCRIPTION
## Problem

`claude-history-explorer` doesn't work on Windows out of the box. Two issues:

### 1. Project discovery finds 0 projects

`projects.py:53` filters with `item.name.startswith("-")`, which assumes macOS/Linux path mangling where `/Users/foo/project` becomes `-Users-foo-project`.

On Windows, `C:\Users\Moho\project` becomes `C--Users-Moho-project` — starts with a drive letter, not a dash. Every project is excluded.

### 2. UnicodeEncodeError on output

Windows terminals default to cp1252 encoding. Rich crashes when rendering Unicode content from transcripts (emojis, em dashes, non-ASCII characters):

```
UnicodeEncodeError: 'charmap' codec can't encode character '\u2014' in position 42
```

## Fix

1. **projects.py**: Changed `startswith("-")` to `not startswith(".")` — includes all project dirs on both platforms while still excluding hidden directories.

2. **cli.py**: Added `sys.stdout/stderr.reconfigure(encoding="utf-8", errors="replace")` on Windows before Console initialization.

## Testing

Tested on Windows 11 with Python 3.13. Both `claude-history projects` and `claude-history search` work correctly with the patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)